### PR TITLE
Ability to create an invoice via REST API and WP CLI - ADDED

### DIFF
--- a/includes/class-wpinv-cli.php
+++ b/includes/class-wpinv-cli.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Contains the main CLI class
+ *
+ * @since 1.0.13
+ * @package Invoicing
+ */
+ 
+// MUST have WordPress.
+if ( !defined( 'WPINC' ) ) {
+    exit;
+}
+
+/**
+ * The main class responsible for registering CLI commands
+ * @since 1.0.13
+ */
+class WPInv_CLI {
+
+    /**
+     * Creates a new invoice
+     * 
+     *  @param Array $args Arguments in array format.
+     *  @param Array $assoc_args Key value arguments stored in associated array format.
+     *  @since 1.0.13
+     */
+    public function insert_invoice( $args, $assoc_args ) {
+
+        // Fetch invoice data from the args
+        $invoice_data = wp_unslash( $assoc_args );
+
+        // Abort if no invoice data is provided
+        if( empty( $invoice_data ) ) {
+            return WP_CLI::error( __( 'Invoice data not provided', 'invoicing' ) );
+        }
+
+        //Cart details
+        if( !empty( $invoice_data['cart_details'] ) ) {
+            $invoice_data['cart_details'] = json_decode( $invoice_data['cart_details'], true );
+        }
+
+        //User details
+        if( !empty( $invoice_data['user_info'] ) ) {
+            $invoice_data['user_info'] = json_decode( $invoice_data['user_info'], true );
+        }
+
+        //Payment info
+        if( !empty( $invoice_data['payment_details'] ) ) {
+            $invoice_data['payment_details'] = json_decode( $invoice_data['payment_details'], true );
+        }
+
+        // Try creating the invoice
+        $invoice = wpinv_insert_invoice( $invoice_data, true );
+
+        if ( is_wp_error( $invoice ) ) {
+            return WP_CLI::error( $invoice->get_error_message() );
+        }
+
+        $message = sprintf( __( 'Invoice %s created', 'invoicing' ), $invoice->ID );
+        WP_CLI::success( $message );
+    }
+    
+    
+}

--- a/includes/class-wpinv.php
+++ b/includes/class-wpinv.php
@@ -21,6 +21,7 @@ class WPInv_Plugin {
             self::$instance->actions();
             self::$instance->notes      = new WPInv_Notes();
             self::$instance->reports    = new WPInv_Reports();
+            self::$instance->api        = new WPInv_API();
         }
 
         return self::$instance;
@@ -179,6 +180,12 @@ class WPInv_Plugin {
             if($pagenow=='users.php'){
                 new WPInv_Admin_Users();
             }
+        }
+
+        // Register cli commands
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            require_once( WPINV_PLUGIN_DIR . 'includes/class-wpinv-cli.php' );
+            WP_CLI::add_command( 'invoicing', 'WPInv_CLI' );
         }
         
         // include css inliner

--- a/includes/wpinv-invoice-functions.php
+++ b/includes/wpinv-invoice-functions.php
@@ -21,15 +21,23 @@ function wpinv_get_invoice_cart_id() {
     return NULL;
 }
 
+/**
+ * Create an invoice
+ * 
+ * @param  array         $invoice_data   An array of invoice properties.
+ * @param  bool          $wp_error       Whether to return false or WP_Error on failure.
+ * @return mixed         The value 0 or WP_Error on failure. The WPInv_Invoice object on success.
+ */
 function wpinv_insert_invoice( $invoice_data = array(), $wp_error = false ) {
     if ( empty( $invoice_data ) ) {
         return false;
     }
     
     if ( !( !empty( $invoice_data['cart_details'] ) && is_array( $invoice_data['cart_details'] ) ) ) {
-        return $wp_error ? new WP_Error( 'wpinv_invalid_items', __( 'Invoice must have atleast on item.', 'invoicing' ) ) : 0;
+        return $wp_error ? new WP_Error( 'wpinv_invalid_items', __( 'Invoice must have atleast one item.', 'invoicing' ) ) : 0;
     }
     
+    // If no user id is provided, default to the current user id
     if ( empty( $invoice_data['user_id'] ) ) {
         $invoice_data['user_id'] = get_current_user_id();
     }
@@ -565,7 +573,7 @@ function wpinv_get_items( $invoice_id = 0 ) {
         foreach ( $items as $key => $item ) {
             $items[$key]['currency'] = $invoice_currency;
 
-            if ( !isset( $cart_item['subtotal'] ) ) {
+            if ( !isset( $item['subtotal'] ) ) {
                 $items[$key]['subtotal'] = $items[$key]['amount'] * 1;
             }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ Automatic updates should seamlessly work. We always suggest you backup up your w
 
 = 1.0.13 =
 * Extensions page Gateways not able to be installed via single key - FIXED
+* Ability to create an invoice via REST API and WP CLI - ADDED
 
 = 1.0.12 =
 * Super Duper updated to v1.0.15 - CHANGED


### PR DESCRIPTION
Makes it possible to create an invoice via the API and CLI.

## API

send a POST request to `wp-json/invoicing/v1/invoices` and include the same arguments passed to [wpinv_insert_invoice](https://wpinvoicing.com/docs/developers/wpinv_insert_invoice/#parameters) in the request body.

The response will include the invoice details of the newly created invoice.

## CLI

Use the command `wp invoicing insert_invoice` to create an invoice.

The arguments are the same as those used when calling [wpinv_insert_invoice](https://wpinvoicing.com/docs/developers/wpinv_insert_invoice/#parameters) except that you use JSON instead of arrays.
