### PR TITLE
Change invoice address format based on the customer's billing country- ADDED

### DIFF
--- a/includes/wpinv-address-functions.php
+++ b/includes/wpinv-address-functions.php
@@ -1570,15 +1570,74 @@ function wpinv_default_billing_country( $country = '', $user_id = 0 ) {
 }
 
 /**
+ * Returns country address formats.
+ *
+ * These define how addresses are formatted for display in various countries.
+ *
+ * @return array
+ */
+function wpinv_get_address_formats() {
+
+		return apply_filters( 'wpinv_localisation_address_formats',
+			array(
+				'default' => "{{name}}\n{{company}}\n{{address}}\n{{city}}\n{{state}}\n{{zip}}\n{{country}}",
+				'AU'      => "{{name}}\n{{company}}\n{{address}}\n{{city}}\n{{state}} {{zip}}\n{{country}}",
+				'AT'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'BE'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'CA'      => "{{company}}\n{{name}}\n{{address}}\n{{city}} {{state_code}}&nbsp;&nbsp;{{zip}}\n{{country}}",
+				'CH'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'CL'      => "{{company}}\n{{name}}\n{{address}}\n{{state}}\n{{zip}} {{city}}\n{{country}}",
+				'CN'      => "{{country}} {{zip}}\n{{state}}, {{city}}, {{address}}\n{{company}}\n{{name}}",
+				'CZ'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'DE'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'EE'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'FI'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'DK'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'FR'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city_upper}}\n{{country}}",
+				'HK'      => "{{company}}\n{{first_name}} {{last_name_upper}}\n{{address}}\n{{city_upper}}\n{{state_upper}}\n{{country}}",
+				'HU'      => "{{name}}\n{{company}}\n{{city}}\n{{address}}\n{{zip}}\n{{country}}",
+				'IN'      => "{{company}}\n{{name}}\n{{address}}\n{{city}} {{zip}}\n{{state}}, {{country}}",
+				'IS'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'IT'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}}\n{{city}}\n{{state_upper}}\n{{country}}",
+				'JP'      => "{{zip}}\n{{state}} {{city}} {{address}}\n{{company}}\n{{last_name}} {{first_name}}\n{{country}}",
+				'TW'      => "{{company}}\n{{last_name}} {{first_name}}\n{{address}}\n{{state}}, {{city}} {{zip}}\n{{country}}",
+				'LI'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'NL'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'NZ'      => "{{name}}\n{{company}}\n{{address}}\n{{city}} {{zip}}\n{{country}}",
+				'NO'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'PL'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'PT'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'SK'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'RS'      => "{{name}}\n{{company}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'SI'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'ES'      => "{{name}}\n{{company}}\n{{address}}\n{{zip}} {{city}}\n{{state}}\n{{country}}",
+				'SE'      => "{{company}}\n{{name}}\n{{address}}\n{{zip}} {{city}}\n{{country}}",
+				'TR'      => "{{name}}\n{{company}}\n{{address}}\n{{zip}} {{city}} {{state}}\n{{country}}",
+				'UG'      => "{{name}}\n{{company}}\n{{address}}\n{{city}}\n{{state}}, {{country}}",
+				'US'      => "{{name}}\n{{company}}\n{{address}}\n{{city}}, {{state_code}} {{zip}}\n{{country}}",
+				'VN'      => "{{name}}\n{{company}}\n{{address}}\n{{city}}\n{{country}}",
+			)
+		);
+}
+
+/**
  * Retrieves the address format to use on Invoices.
  * 
  * @since 1.0.13
  * @see `wpinv_get_invoice_address_replacements`
  * @return string
  */
-function wpinv_get_full_address_format() {
+function wpinv_get_full_address_format( $country = false) {
 
-    $format = "{{address}} \n\n {{city}}, {{state}} \n\n {{country}} {{zip}}";
+    if( empty( $country ) ) {
+        $country = wpinv_get_default_country();
+    }
+
+    // Get all formats.
+	$formats = wpinv_get_address_formats();
+
+	// Get format for the specified country.
+	$format = ( $country && isset( $formats[ $country ] ) ) ? $formats[ $country ] : $formats['default'];
     
     /**
 	 * Filters the address format to use on Invoices.
@@ -1602,37 +1661,34 @@ function wpinv_get_full_address_format() {
  */
 function wpinv_get_invoice_address_replacements( $billing_details ) {
 
-    $replacements = array(
-        'address'        => '',
-        'city'           => '',
-        'state'          => '',
-        'country'        => '',
-        'country_code'   => '',
-        'zip'            => '',
+    $default_args = array(
+        'address'           => '',
+        'city'              => '',
+        'state'             => '',
+        'country'           => '',
+        'zip'               => '',
+        'first_name'        => '',
+		'last_name'         => '',
+		'company'           => '',
     );
 
-    if( ! empty( $billing_details['address'] ) ) {
-        $replacements['address'] = sanitize_text_field( $billing_details['address'] );
-    }
-
-    if( ! empty( $billing_details['city'] ) ) {
-        $replacements['city'] = sanitize_text_field( $billing_details['city'] );
-    }
-
-    if( ! empty( $billing_details['zip'] ) ) {
-        $replacements['zip'] = sanitize_text_field( $billing_details['zip'] );
-    }
+    $args    = array_map( 'trim', wp_parse_args( $billing_details, $default_args ) );
+    $state   = $args['state'];
+    $country = $args['country'];
     
-    $billing_country = !empty( $billing_details['country'] ) ? $billing_details['country'] : '';
-    if ( !empty( $billing_details['state'] ) ) {
-        $replacements['state'] = sanitize_text_field( wpinv_state_name( $billing_details['state'], $billing_country ) );
-    }
-
-    if ( !empty( $billing_country ) ) {
-        $replacements['country']      = wpinv_country_name( $billing_country );
-        $replacements['country_code'] = sanitize_text_field( $billing_country );
-    }
+    // Handle full country name.
+    $full_country = empty( $country ) ? $country : wpinv_country_name( $country );
     
+    // Handle full state name.
+    $full_state   = ( $country && $state ) ?  wpinv_state_name( $state, $country ) : $state;
+
+    $args['postcode']    = $args['zip'];
+    $args['name']        = $args['first_name'] . ' ' . $args['last_name'];
+    $args['state']       = $full_state;
+    $args['state_code']  = $state;
+    $args['country']     = $full_country;
+    $args['country_code']= $country;
+
     /**
 	 * Filters the address format replacements to use on Invoices.
      * 
@@ -1642,5 +1698,27 @@ function wpinv_get_invoice_address_replacements( $billing_details ) {
 	 * @param array $replacements  The address replacements to use.
      * @param array $billing_details  The billing details to use.
 	 */
-    return apply_filters( 'wpinv_get_invoice_address_replacements', $replacements, $billing_details );
+    $replacements = apply_filters( 'wpinv_get_invoice_address_replacements', $args, $billing_details );
+
+    $return = array();
+
+    foreach( $replacements as $key => $value ) {
+        $value  = is_scalar( $value ) ? trim( sanitize_text_field( $value ) ) : '';
+        $return['{{' . $key . '}}'] = $value;
+        $return['{{' . $key . '_upper}}'] = wpinv_utf8_strtoupper( $value );
+    }
+
+    return $return;
+
+}
+
+/**
+ * Trim white space and commas off a line.
+ *
+ * @param  string $line Line.
+ * @since 1.0.14
+ * @return string
+ */
+function wpinv_trim_formatted_address_line( $line ) {
+	return trim( $line, ', ' );
 }

--- a/includes/wpinv-template-functions.php
+++ b/includes/wpinv-template-functions.php
@@ -933,26 +933,35 @@ function wpinv_display_invoice_details( $invoice ) {
  * @see `wpinv_get_full_address_format`
  * @see `wpinv_get_invoice_address_replacements`
  * @param array $billing_details customer's billing details
+ * @param  string $separator How to separate address lines.
  * @return string
  */
-function wpinv_get_invoice_address_markup( $billing_details ) {
+function wpinv_get_invoice_address_markup( $billing_details, $separator = '<br/>' ) {
 
     // Retrieve the address markup...
-    $markup = wpinv_get_full_address_format();
+    $country= empty( $billing_details['country'] ) ? '' : $billing_details['country'];
+    $format = wpinv_get_full_address_format( $country );
 
     // ... and the replacements.
     $replacements = wpinv_get_invoice_address_replacements( $billing_details );
 
-    // Replace all available tags with their values.
-	foreach( $replacements as $key => $value ) {
-		$markup = str_ireplace( '{{' . $key . '}}', $value, $markup );
-    }
+    $formatted_address = str_ireplace( array_keys( $replacements ), $replacements, $format );
     
 	// Remove unavailable tags.
-    $markup = preg_replace( "/\{\{\w+}\}/", '', $markup );
+    $formatted_address = preg_replace( "/\{\{\w+\}\}/", '', $formatted_address );
 
-    // Finally, clean then return the output.
-    return wpautop( wp_kses_post( trim( $markup ) ) );
+    // Clean up white space.
+	$formatted_address = preg_replace( '/  +/', ' ', trim( $formatted_address ) );
+    $formatted_address = preg_replace( '/\n\n+/', "\n", $formatted_address );
+    
+    // Break newlines apart and remove empty lines/trim commas and white space.
+	$formatted_address = array_filter( array_map( 'wpinv_trim_formatted_address_line', explode( "\n", $formatted_address ) ) );
+
+    // Add html breaks.
+	$formatted_address = implode( $separator, $formatted_address );
+
+	// We're done!
+	return $formatted_address;
     
 }
 
@@ -971,11 +980,6 @@ function wpinv_display_to_address( $invoice_id = 0 ) {
     do_action( 'wpinv_display_to_address_top', $invoice );
     $output .= ob_get_clean();
     
-    $output .= '<div class="name">' . esc_html( trim( $billing_details['first_name'] . ' ' . $billing_details['last_name'] ) ) . '</div>';
-    if ( $company = $billing_details['company'] ) {
-        $output .= '<div class="company">' . wpautop( wp_kses_post( $company ) ) . '</div>';
-    }
-
     $address_row = wpinv_get_invoice_address_markup( $billing_details );
 
     if ( $address_row ) {
@@ -1879,12 +1883,6 @@ function wpinv_receipt_billing_address( $invoice_id = 0 ) {
                 <th class="text-left"><?php _e( 'Email', 'invoicing' ); ?></th>
                 <td><?php echo $billing_details['email'] ;?></td>
             </tr>
-            <?php if ( $billing_details['company'] ) { ?>
-            <tr class="wpi-receipt-company">
-                <th class="text-left"><?php _e( 'Company', 'invoicing' ); ?></th>
-                <td><?php echo esc_html( $billing_details['company'] ) ;?></td>
-            </tr>
-            <?php } ?>
             <tr class="wpi-receipt-address">
                 <th class="text-left"><?php _e( 'Address', 'invoicing' ); ?></th>
                 <td><?php echo $address_row ;?></td>

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,9 @@ Automatic updates should seamlessly work. We always suggest you backup up your w
 
 == Changelog ==
 
+= 1.0.14 =
+* Change invoice address format based on the customer's billing country - ADDED
+
 = 1.0.13 =
 * Extensions page Gateways not able to be installed via single key - FIXED
 * Ability to create, read, update and delete an invoice via REST API - ADDED


### PR DESCRIPTION
Address formats now adapt to the customer's billing country.

Currently, only a handful of countries have specific formats https://github.com/AyeCode/invoicing/blob/403be3c5f95f187e956eff8d430d0c07852d92f1/includes/wpinv-address-functions.php#L1581-L1620

Other countries will use the default address format. 
```
{{name}}
{{company}}
{address}}
{{city}}
{{state}}
{{zip}}
{{country}}
```

If you wish, you can use the following filter to specify a single address format that will be used on all invoices regardless of the customer's home country:-

https://github.com/AyeCode/invoicing/blob/403be3c5f95f187e956eff8d430d0c07852d92f1/includes/wpinv-address-functions.php#L1651

The address placeholders are replaced by the customer's user info. You can add more replacements using the following filter:-
https://github.com/AyeCode/invoicing/blob/403be3c5f95f187e956eff8d430d0c07852d92f1/includes/wpinv-address-functions.php#L1701

## Available placeholders

- user_id
- first_name
- last_name
- name
- email
- phone
- address
- city
- country
- country_code
- state
- state_code
- zip
- postcode 
- company
- vat_number
- first_name_upper
- last_name_upper
- name_upper
- email_upper
- address_upper
- city_upper
- country_upper
- country_code_upper
- state_upper
- state_code_upper
- zip_upper
- postcode_upper
- company_upper
- vat_number_upper