### PR TITLE
Privacy improvements

### DIFF
--- a/includes/class-wpinv-privacy-exporters.php
+++ b/includes/class-wpinv-privacy-exporters.php
@@ -41,10 +41,11 @@ class WPInv_Privacy_Exporters {
         if ( 0 < count( $invoices ) ) {
             foreach ( $invoices as $invoice ) {
                 $data_to_export[] = array(
-                    'group_id'    => 'customer_invoices',
-                    'group_label' => __( 'Invoicing Data', 'invoicing' ),
-                    'item_id'     => "wpinv-{$invoice->ID}",
-                    'data'        => self::get_customer_invoice_data( $invoice ),
+                    'group_id'          => 'customer_invoices',
+                    'group_label'       => __( 'Invoicing Data', 'invoicing' ),
+                    'group_description' => __( 'Customer invoicing data.', 'invoicing' ),
+                    'item_id'           => "wpinv-{$invoice->ID}",
+                    'data'              => self::get_customer_invoice_data( $invoice ),
                 );
             }
             $done = 30 > count( $invoices );

--- a/includes/class-wpinv-privacy.php
+++ b/includes/class-wpinv-privacy.php
@@ -30,10 +30,9 @@ class WPInv_Privacy extends WPInv_Abstract_Privacy {
      */
     public function get_privacy_message() {
 
-        $content = '<h2>' . __( 'Invoices and checkout', 'invoicing' ) . '</h2>' .
-                   '<div contenteditable="false">' .
-                   '<p class="wp-policy-help">' . __( 'Example privacy texts.', 'invoicing' ) . '</p>' .
-                   '</div>' .
+        $content = '<div class="wp-suggested-text">' .
+                   '<h2>' . __( 'Invoices and checkout', 'invoicing' ) . '</h2>' .
+                   '<p class="privacy-policy-tutorial">' . __( 'Example privacy texts.', 'invoicing' ) . '</p>' .
                    '<p>' . __( 'We collect information about you during the checkout process on our site. This information may include, but is not limited to, your name, email address, phone number, address, IP and any other details that might be requested from you for the purpose of processing your payment and retaining your invoice details for legal reasons.', 'invoicing' ) . '</p>' .
                    '<p>' . __( 'Handling this data also allows us to:', 'invoicing' ) . '</p>' .
                    '<ul>' .
@@ -47,20 +46,10 @@ class WPInv_Privacy extends WPInv_Abstract_Privacy {
                    '<p>' . __( 'In addition to collecting information at checkout we may also use and store your contact details when manually creating invoices for require payments relating to prior contractual agreements or agreed terms.', 'invoicing' ) . '</p>' .
                    '<h2>' . __( 'What we share with others', 'invoicing' ) . '</h2>' .
                    '<p>' . __( 'We share information with third parties who help us provide our payment and invoicing services to you; for example --', 'invoicing' ) . '</p>' .
-                   '<div contenteditable="false">' .
-                   '<p class="wp-policy-help">' . __( 'In this subsection you should list which third party payment processors you’re using to take payments since these may handle customer data. We’ve included PayPal as an example, but you should remove this if you’re not using PayPal.', 'invoicing' ) . '</p>' .
-                   '</div>' .
+                   '<p class="privacy-policy-tutorial">' . __( 'In this subsection you should list which third party payment processors you’re using to take payments since these may handle customer data. We’ve included PayPal as an example, but you should remove this if you’re not using PayPal.', 'invoicing' ) . '</p>' .
                    '<p>' . __( 'We accept payments through PayPal. When processing payments, some of your data will be passed to PayPal, including information required to process or support the payment, such as the purchase total and billing information.', 'invoicing' ) . '</p>' .
-                   '<p>' . __( 'Please see the <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">PayPal Privacy Policy</a> for more details.', 'invoicing' ) . '</p>';
-
-
-
-//        $content = '
-//			<div contenteditable="false">' .
-//            '<p class="wp-policy-help">' .
-//            __( 'Invoicing uses the following privacy.', 'invoicing' ) .
-//            '</p>' .
-//            '</div>';
+                   '<p>' . __( 'Please see the <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">PayPal Privacy Policy</a> for more details.', 'invoicing' ) . '</p>' .
+                   '</div>';
 
         return apply_filters( 'wpinv_privacy_policy_content', $content );
     }


### PR DESCRIPTION
Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping <div contenteditable="false"> as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.