### PR TITLE
Return canceled PayPal transactions to the checkout page instead of the payment failed page - CHANGED

### DIFF
--- a/includes/gateways/paypal.php
+++ b/includes/gateways/paypal.php
@@ -61,7 +61,7 @@ function wpinv_process_paypal_payment( $purchase_data ) {
             'custom'        => $invoice->ID,
             'rm'            => '2',
             'return'        => $return_url,
-            'cancel_return' => wpinv_get_failed_transaction_uri( '?invoice-id=' . $invoice->ID ),
+            'cancel_return' => $invoice->get_checkout_payment_url(),
             'notify_url'    => $listener_url,
             'cbt'           => get_bloginfo( 'name' ),
             'bn'            => 'WPInvoicing_SP',

--- a/readme.txt
+++ b/readme.txt
@@ -127,8 +127,11 @@ Automatic updates should seamlessly work. We always suggest you backup up your w
 
 == Changelog ==
 
+= 1.0.15 =
+* Return canceled PayPal transactions to the checkout page instead of the payment failed page - CHANGED
+
 = 1.0.14 =
-* Support for group_description for privacy exporters (thanks @garretthyder) - Added
+* Support for group_description for privacy exporters (thanks @garretthyder) - ADDED
 * Default buy now button text - ADDED
 * Users with a manage_invoicing capability can view subscriptions - ADDED
 * Missing "Add New" button on item overview pages - FIXED


### PR DESCRIPTION
Currently, when a user checks out via PayPal and decides to "cancel the transaction and return to merchant", PayPal redirects them to our order failed page. When they visit the checkout page, it shows a cart empty error.

With this PR, users are now redirected to the checkout page so that they can select a different Payment Gateway.

@see https://wpinvoicing.com/support/topic/transaction-fails-if-user-clicks-on-backbutton/