### PR TITLE
Hide invoice counts on public facing UWP pages

### DIFF
--- a/includes/wpinv-post-types.php
+++ b/includes/wpinv-post-types.php
@@ -301,3 +301,18 @@ function wpinv_register_post_status() {
     ) );
 }
 add_action( 'init', 'wpinv_register_post_status', 10 );
+
+/**
+ * Hides invoice counts on public facing user profile pages.
+ * 
+ * @link https://wpinvoicing.com/support/topic/number-of-invoices-show-on-a-public-profile/
+ */
+function wpinv_hide_uwp_user_invoices_count( $counts ){
+
+    if ( apply_filters( 'wpinv_hide_uwp_user_invoices_count', true ) && isset( $counts['wpi_invoice'] ) ) {
+	    unset( $counts['wpi_invoice'] );
+    }
+
+    return $counts;
+}
+add_filter('uwp_get_user_post_counts', 'wpinv_hide_uwp_user_invoices_count' );

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ Automatic updates should seamlessly work. We always suggest you backup up your w
 * `wpinv_create_invoice()` and `wpinv_insert_invoice()` functions now support creating quotes - CHANGED
 * Invoices api now supports querying items by meta fields and dates - ADDED
 * Return canceled PayPal transactions to the checkout page instead of the payment failed page - CHANGED
+* Hide invoice counts on public facing UWP profile pages - ADDED
 
 = 1.0.14 =
 * Support for group_description for privacy exporters (thanks @garretthyder) - ADDED


### PR DESCRIPTION
https://wpinvoicing.com/support/topic/number-of-invoices-show-on-a-public-profile/

It is not necessary to show a user's number of invoices to the public. This PR auto-hides that, but you can display it hooking into the `wpinv_hide_uwp_user_invoices_count` filter and returning false.