### PR TITLE
a daily cron to expire subscriptions

### DIFF
--- a/includes/class-getpaid-daily-maintenance.php
+++ b/includes/class-getpaid-daily-maintenance.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Daily maintenance class.
+ *
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Daily maintenance class.
+ *
+ */
+class GetPaid_Daily_Maintenance {
+
+    /**
+	 * Class constructor.
+	 */
+    public function __construct(){
+
+        // Clear deprecated events.
+        add_action( 'wp', array( $this, 'maybe_clear_deprecated_events' ) );
+
+        // (Maybe) schedule a cron that runs daily.
+        add_action( 'wp', array( $this, 'maybe_create_scheduled_event' ) );
+
+        // Fired everyday at 7 a.m (this might vary for sites with few visitors)
+        add_action( 'getpaid_daily_maintenance', array( $this, 'backwards_compat' ) );
+        add_action( 'getpaid_daily_maintenance', array( $this, 'maybe_expire_subscriptions' ) );
+        add_action( 'getpaid_daily_maintenance', array( $this, 'maybe_send_upcoming_renewal_reminders' ) );
+        add_action( 'getpaid_daily_maintenance', array( $this, 'maybe_send_overdue_notices' ) );
+
+    }
+
+    /**
+	 * Schedules a cron to run every day at 7 a.m
+     *
+	 */
+    public function maybe_create_scheduled_event() {
+
+        if ( ! wp_next_scheduled( 'getpaid_daily_maintenance' ) ) {
+            $timestamp = strtotime( 'tomorrow 07:00:00', current_time( 'timestamp' ) );
+            wp_schedule_event( $timestamp, 'daily', 'getpaid_daily_maintenance' );
+        }
+
+    }
+
+    /**
+	 * Clears deprecated events.
+     *
+	 */
+    public function maybe_clear_deprecated_events() {
+
+        if ( ! get_option( 'wpinv_cleared_old_events' ) ) {
+            wp_clear_scheduled_hook( 'wpinv_register_schedule_event_twicedaily' );
+            wp_clear_scheduled_hook( 'wpinv_register_schedule_event_daily' );
+            update_option( 'wpinv_cleared_old_events', 1 );
+        }
+        
+    }
+
+    /**
+	 * Fires the old hook for backwards compatibility.
+     *
+	 */
+    public function backwards_compat() {
+        do_action( 'wpinv_register_schedule_event_daily' );
+    }
+
+    /**
+	 * Expires expired subscriptions.
+     *
+	 */
+    public function maybe_expire_subscriptions() {
+
+        // Fetch expired subscriptions (skips those that expire today).
+        $args  = array(
+            'number'             => -1,
+			'count_total'        => false,
+			'status'             => 'trialling active failing cancelled',
+            'date_expires_query' => array(
+                'before'    => 'today',
+                'inclusive' => true,
+            ),
+        );
+
+        $subscriptions = new GetPaid_Subscriptions_Query( $args );
+
+        foreach ( $subscriptions as $subscription ) {
+            $subscription->set_status( 'expired' );
+            $subscription->save();
+        }
+
+    }
+
+}

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -636,3 +636,8 @@ function wpinv_update_invoice_number() {}
  * @deprecated
  */
 function wpinv_invoice_subscription_details() {}
+
+/**
+ * @deprecated
+ */
+function wpinv_schedule_events() {}

--- a/includes/wpinv-general-functions.php
+++ b/includes/wpinv-general-functions.php
@@ -284,21 +284,6 @@ function wpinv_is_ssl_enforced() {
     return (bool) apply_filters( 'wpinv_is_ssl_enforced', $ssl_enforced );
 }
 
-function wpinv_schedule_events() {
-
-    // Get the timestamp for the next event.
-    $timestamp = wp_next_scheduled( 'wpinv_register_schedule_event_twicedaily' );
-
-    if ( $timestamp ) {
-        wp_unschedule_event( $timestamp, 'wpinv_register_schedule_event_twicedaily' );
-    }
-
-    if ( ! wp_next_scheduled( 'wpinv_register_schedule_event_daily' ) ) {
-        wp_schedule_event( current_time( 'timestamp' ), 'daily', 'wpinv_register_schedule_event_daily' );
-    }
-}
-add_action( 'wp', 'wpinv_schedule_events' );
-
 function wpinv_schedule_event_twicedaily() {
     wpinv_email_payment_reminders();
     wpinv_email_renewal_reminders();


### PR DESCRIPTION
Sometimes gateways fail to mark subscriptions as expired (due to an error etc). GetPaid now does this automatically, hence triggering any subscription expired emails.