### PR TITLE
Invoicing and subscription should not be on first position in account tabs

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -204,7 +204,7 @@ function getpaid_filter_userswp_account_tabs( $tabs ) {
 
     }
 
-    return array_merge( $new_tabs, $tabs );
+    return array_merge( $tabs, $new_tabs );
 }
 add_filter( 'uwp_account_available_tabs', 'getpaid_filter_userswp_account_tabs' );
 


### PR DESCRIPTION
## Description
I just changed one line in the code

## How has this been tested?
I tested it on my site.

## Screenshots <!-- if applicable -->
![Account1](https://user-images.githubusercontent.com/32451578/105347199-9428d900-5c0c-11eb-889f-9efd81764959.png)

![Account2](https://user-images.githubusercontent.com/32451578/105347210-99862380-5c0c-11eb-8cfc-5e4d99fe13e5.png)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the [WordPress code style](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->
- [x] I've included developer documentation if appropriate.
