### PR TITLE
Fixed bug during export of private data

### DIFF
--- a/includes/class-wpinv-privacy-exporters.php
+++ b/includes/class-wpinv-privacy-exporters.php
@@ -34,6 +34,7 @@ class WPInv_Privacy_Exporters {
             'limit'    => 30,
             'page'     => $page,
             'user'     => $user->ID,
+            'paginate' => false,
         );
 
         $invoices = wpinv_get_invoices( $args );


### PR DESCRIPTION
## Description
I had problems during the export process of personal informations.

```
[27-Jan-2021 15:58:19 UTC] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in  /wp-content/plugins/invoicing/includes/class-wpinv-privacy-exporters.php on line 41
[27-Jan-2021 15:58:19 UTC] PHP Fatal error:  Uncaught Error: Call to a member function is_recurring() on array in  /wp-content/plugins/invoicing/includes/class-wpinv-privacy-exporters.php:93
Stack trace:
#0  /wp-content/plugins/invoicing/includes/class-wpinv-privacy-exporters.php(48): WPInv_Privacy_Exporters::get_customer_invoice_data(Array)
#1  /wp-admin/includes/ajax-actions.php(4845): WPInv_Privacy_Exporters::customer_invoice_data_exporter('<email>....', 1)
#2  /wp-includes/class-wp-hook.php(287): wp_ajax_wp_privacy_export_personal_data('')
#3  /wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters('', Array)
#4  /wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#5  /wp-admin/admin-ajax.php(176): do_action('wp_ajax_wp-priv...')
#6 {main}
  thrown in  /wp-content/plugins/invoicing/includes/class-wpinv-privacy-exporters.php on line 93
```
After looking into the source I saw that `$invoices` in line 42 doesn't provide an invoice but a key, because `wpinv_get_invoices( $args )` returns an object. After changing the way the invoices are returned (`'paginate' => false`) it returned an array and everything worked properly.

## How has this been tested?
Currently I tested the export-process in a testsystem without any invoices. The test with invoices is planned.

## Types of changes
It's a bug fix that does not break any other code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the [WordPress code style](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->
- [x] I've included developer documentation if appropriate.
