### PR TITLE
Authorize.NET free-trial / zero-total subscriptions stuck as pending

### DIFF
--- a/includes/gateways/class-getpaid-authorize-net-gateway.php
+++ b/includes/gateways/class-getpaid-authorize-net-gateway.php
@@ -1086,6 +1086,10 @@ class GetPaid_Authorize_Net_Gateway extends GetPaid_Authorize_Net_Legacy_Gateway
 		// Check if there is an initial amount to charge.
 		if ( (float) $invoice->get_total() > 0 ) {
 			$this->process_initial_payment( $invoice );
+		} elseif ( $invoice->needs_payment() ) {
+			// No initial charge (free trial or discounted first payment); the payment profile is already stored, so just complete the invoice.
+			$invoice->add_note( wp_sprintf( __( '[Authorize.NET %s]: No initial payment required. Payment profile stored for future recurring charges.', 'invoicing' ), $this->get_mode_name() ), false, false, true );
+			$invoice->mark_paid();
 		}
 
 		// Activate the subscriptions.

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,9 @@ Automatic updates should work seamlessly. To avoid unforeseen problems, we alway
 
 == Changelog ==
 
+= 2.8.56 - TBD =
+* Authorize.NET subscriptions with a free trial or zero-total first payment left the invoice stuck as pending - FIXED
+
 = 2.8.55 - 2026-07-08 =
 * Verify nonce and invoice ownership before processing checkout - SECURITY
 * Validate payment form uploads against allowed file types - SECURITY


### PR DESCRIPTION
**Problem**
When a customer signs up for an Authorize.NET subscription where the first payment is $0 (free trial, or a promo code that discounts the first payment to zero), the invoice was left in Pending Payment. The customer sees a "complete your payment" state even though nothing is owed, and the signup looks unfinished.

**Cause**
process_subscription() only completed the invoice as a side effect of charging the initial payment. With a $0 initial amount there's no charge, so the invoice was never marked paid.

**Fix**
When there's no initial amount to charge, mark the invoice paid directly (the card/payment profile is already stored for future renewals). Guarded with needs_payment() so it only runs on a pending invoice. Paid subscriptions with a normal first charge are unaffected.

**Result**
$0 first-payment signups now complete as Paid, the subscription starts trialling, and renewals charge automatically.