### PR TITLE
Fix Country/State searchable dropdowns on payment forms

### DIFF
--- a/includes/payments/class-getpaid-payment-form.php
+++ b/includes/payments/class-getpaid-payment-form.php
@@ -796,6 +796,8 @@ $value[ $key ]['description'] = $help_text;}
 	 * @since 1.0.19
 	 */
     public function display( $extra_markup = '' ) {
+		getpaid_enqueue_select2();
+
 		wpinv_get_template(
 			'payment-forms/form.php',
 			array(

--- a/includes/wpinv-template-functions.php
+++ b/includes/wpinv-template-functions.php
@@ -1366,11 +1366,30 @@ function getpaid_convert_items_to_string( $items ) {
 }
 
 /**
+ * Enqueues select2, used by the payment form country and state fields.
+ *
+ * Payment forms are loaded over AJAX, so select2 has to be enqueued by whatever
+ * renders first on the page, either the payment button or an inline form.
+ *
+ * @since 2.8.59
+ */
+function getpaid_enqueue_select2() {
+
+    if ( is_admin() || ! apply_filters( 'getpaid_load_select2', true ) ) {
+        return;
+    }
+
+    wp_enqueue_script( 'select2' );
+}
+
+/**
  * Helper function to display a payment item.
  *
  * Provide a label and one of $form, $items or $invoice.
  */
 function getpaid_get_payment_button( $label, $form = null, $items = null, $invoice = null, $variation = null ) {
+    getpaid_enqueue_select2();
+
     $label          = sanitize_text_field( $label );
     $variation_attr = ! empty( $variation ) ? " data-variation='" . esc_attr( $variation ) . "'" : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,9 @@ Automatic updates should work seamlessly. To avoid unforeseen problems, we alway
 
 == Changelog ==
 
+= 2.8.59 - TBD =
+* Country and State/Province searchable dropdowns were not working on payment forms - FIXED
+
 = 2.8.58 - 2026-08-18 =
 * Merge AUI 0.2.52 & SD 1.2.35 - CHANGED
 


### PR DESCRIPTION
Two separate defects produced the same symptom:

select2 was never enqueued on the frontend. AUI only auto-loads it in wp-admin, and its render-time enqueue cannot help because payment forms are delivered over AJAX. aui_init_select2() therefore threw a TypeError and aborted the rest of form init. Enqueue select2 from whatever renders first on the page - the payment button or an inline form - rather than adding it as a global dependency, so it stays off pages that do not need it.

Select2 was also unusable inside the modal: without a dropdownParent its dropdown is appended to <body>, and the Bootstrap focus trap then pulled focus back to the modal's first field. Vendored copy of the AUI fix, which is committed separately in ayecode/wp-ayecode-ui and will arrive here with the next AUI release.