### PR TITLE
Narrow select2 enqueue to the payment form modal

### DIFF
--- a/includes/payments/class-getpaid-payment-form.php
+++ b/includes/payments/class-getpaid-payment-form.php
@@ -796,8 +796,6 @@ $value[ $key ]['description'] = $help_text;}
 	 * @since 1.0.19
 	 */
     public function display( $extra_markup = '' ) {
-		getpaid_enqueue_select2();
-
 		wpinv_get_template(
 			'payment-forms/form.php',
 			array(

--- a/includes/wpinv-template-functions.php
+++ b/includes/wpinv-template-functions.php
@@ -1368,8 +1368,7 @@ function getpaid_convert_items_to_string( $items ) {
 /**
  * Enqueues select2, used by the payment form country and state fields.
  *
- * Payment forms are loaded over AJAX, so select2 has to be enqueued by whatever
- * renders first on the page, either the payment button or an inline form.
+ * Modal forms are loaded over AJAX, too late for AUI to enqueue it itself.
  *
  * @since 2.8.59
  */

--- a/readme.txt
+++ b/readme.txt
@@ -147,7 +147,7 @@ Automatic updates should work seamlessly. To avoid unforeseen problems, we alway
 == Changelog ==
 
 = 2.8.59 - TBD =
-* Country and State/Province searchable dropdowns were not working on payment forms - FIXED
+* Country and State/Province dropdowns were not working in the payment form modal - FIXED
 
 = 2.8.58 - 2026-08-18 =
 * Merge AUI 0.2.52 & SD 1.2.35 - CHANGED


### PR DESCRIPTION
Only the modal was affected: it loads its form over AJAX, after the page has printed its scripts. Forms rendered inline are enqueued by AUI itself at render time, so the hook in GetPaid_Payment_Form::display() never did anything and is removed. Changelog and docblock reworded to match.
